### PR TITLE
/tools/view route with URL

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -10,7 +10,8 @@
     "next-env.d.ts",
     "**/*.tsx",
     "**/*.ts",
-    ".contentlayer/generated"
+    ".contentlayer/generated",
+    "lib"
   ],
   "exclude": ["node_modules"]
 }

--- a/lib/markdown.js
+++ b/lib/markdown.js
@@ -1,31 +1,36 @@
-import matter from 'gray-matter'
-import toc from 'remark-toc'
-import gfm from 'remark-gfm'
+import matter from "gray-matter";
+import toc from "remark-toc";
+import gfm from "remark-gfm";
 
-import { serialize } from 'next-mdx-remote/serialize'
+import { serialize } from "next-mdx-remote/serialize";
 
 /**
  * Parse a markdown or MDX file to an MDX source form + front matter data
  *
  * @source: the contents of a markdown or mdx file
+ * @mdxPath: the path, used to indicate to next-mdx-remote which format to use
  * @returns: { mdxSource: mdxSource, frontMatter: ...}
  */
-const parse = async function(source) {
-  const { content, data } = matter(source)
+const parse = async function (source, mdxPath) {
+  const { content, data } = matter(source);
 
-  const mdxSource = await serialize(content, {
-    // Optionally pass remark/rehype plugins
-    mdxOptions: {
-      remarkPlugins: [gfm, toc],
-      rehypePlugins: [],
-    },
-    scope: data,
-  })
+  const mdxSource = await serialize(
+    { value: content, path: mdxPath },
+    {
+      // Optionally pass remark/rehype plugins
+      mdxOptions: {
+        remarkPlugins: [gfm, toc],
+        rehypePlugins: [],
+        format: "detect",
+      },
+      scope: data,
+    }
+  );
 
   return {
     mdxSource: mdxSource,
-    frontMatter: data
-  }
-}
+    frontMatter: data,
+  };
+};
 
-export default parse
+export default parse;

--- a/lib/markdown.js
+++ b/lib/markdown.js
@@ -1,6 +1,17 @@
 import matter from "gray-matter";
-import toc from "remark-toc";
-import gfm from "remark-gfm";
+import { h } from "hastscript";
+import remarkGfm from "remark-gfm";
+import remarkMath from "remark-math";
+import remarkSmartypants from "remark-smartypants";
+import remarkToc from "remark-toc";
+import remarkCallouts from "@flowershow/remark-callouts";
+import remarkEmbed from "@flowershow/remark-embed";
+import remarkWikilink from "@flowershow/remark-wiki-link";
+import mdxmermaid from "mdx-mermaid";
+import rehypeAutolinkHeadings from "rehype-autolink-headings";
+import rehypeMathjax from "rehype-mathjax";
+import rehypeSlug from "rehype-slug";
+import rehypePrismPlus from "rehype-prism-plus";
 
 import { serialize } from "next-mdx-remote/serialize";
 
@@ -19,8 +30,61 @@ const parse = async function (source, mdxPath) {
     {
       // Optionally pass remark/rehype plugins
       mdxOptions: {
-        remarkPlugins: [gfm, toc],
-        rehypePlugins: [],
+        remarkPlugins: [
+          remarkGfm,
+          [
+            remarkToc,
+            {
+              heading: "Table of contents",
+              tight: true,
+            },
+          ],
+          remarkMath,
+          [remarkSmartypants, { quotes: false, dashes: "oldschool" }],
+          remarkCallouts,
+          remarkEmbed,
+          [remarkWikilink, { markdownFolder: "/content" }],
+          [mdxmermaid, {}],
+        ],
+        rehypePlugins: [
+          rehypeSlug,
+          [
+            rehypeAutolinkHeadings,
+            {
+              test(element) {
+                return (
+                  ["h2", "h3", "h4", "h5", "h6"].includes(element.tagName) &&
+                  element.properties?.id !== "table-of-contents" &&
+                  element.properties?.className !== "blockquote-heading"
+                );
+              },
+              content() {
+                return [
+                  h(
+                    "svg",
+                    {
+                      xmlns: "http://www.w3.org/2000/svg",
+                      fill: "#ab2b65",
+                      viewBox: "0 0 20 20",
+                      className: "w-5 h-5 inline-block mr-2",
+                    },
+                    [
+                      h("path", {
+                        fillRule: "evenodd",
+                        clipRule: "evenodd",
+                        d: "M9.493 2.853a.75.75 0 00-1.486-.205L7.545 6H4.198a.75.75 0 000 1.5h3.14l-.69 5H3.302a.75.75 0 000 1.5h3.14l-.435 3.148a.75.75 0 001.486.205L7.955 14h2.986l-.434 3.148a.75.75 0 001.486.205L12.456 14h3.346a.75.75 0 000-1.5h-3.14l.69-5h3.346a.75.75 0 000-1.5h-3.14l.435-3.147a.75.75 0 00-1.486-.205L12.045 6H9.059l.434-3.147zM8.852 7.5l-.69 5h2.986l.69-5H8.852z",
+                      }),
+                    ]
+                  ),
+                ];
+              },
+            },
+          ],
+          // There's a known hydration issue with Next + Mathjax
+          // https://github.com/remarkjs/remark-math/issues/80
+          // rehypeMathjax,
+          [rehypePrismPlus, { ignoreMissing: true }],
+        ],
         format: "detect",
       },
       scope: data,

--- a/lib/remoteFiles.js
+++ b/lib/remoteFiles.js
@@ -1,0 +1,27 @@
+import axios from "axios";
+
+export function validateUrl(string) {
+  let url;
+  try {
+    url = new URL(string);
+  } catch (_) {
+    return false;
+  }
+  return url.protocol === "http:" || url.protocol === "https:";
+}
+
+export async function getContentFromUrl(url) {
+  //  We can improve the error handling later
+  //  For now, it's going to display the 500 error
+  //  page on prod and the error overlay on dev
+  if (!validateUrl(url)) {
+    throw new Error("Invalid URL");
+  }
+
+  return axios
+    .get(url)
+    .then((r) => r.data)
+    .catch((e) => {
+      throw new Error("URL could not be found");
+    });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
       "version": "1.0.0",
       "dependencies": {
         "@docsearch/react": "^3.2.0",
+        "@flowershow/remark-callouts": "^1.0.0",
+        "@flowershow/remark-embed": "^1.0.0",
+        "@flowershow/remark-wiki-link": "^1.0.0",
         "@headlessui/react": "^1.6.6",
         "@heroicons/react": "^1.0.4",
         "@silvenon/remark-smartypants": "^1.0.0",
@@ -434,6 +437,32 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@fal-works/esbuild-plugin-global-externals/-/esbuild-plugin-global-externals-2.1.2.tgz",
       "integrity": "sha512-cEee/Z+I12mZcFJshKcCqC8tuX5hG3s+d+9nZ3LabqKF1vKdF41B92pJVCBggjAGORAeOzyyDDKrZwIkLffeOQ=="
+    },
+    "node_modules/@flowershow/remark-callouts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@flowershow/remark-callouts/-/remark-callouts-1.0.0.tgz",
+      "integrity": "sha512-zzHDpw1bswTTf+cbhNh2Bogf4ghpIcxAypFxYZxZ/afeGdN3NNSQwnamL8StY9uu6aQ/miq4Egbuof3xk2ksWA==",
+      "dependencies": {
+        "mdast-util-from-markdown": "^1.2.0",
+        "svg-parser": "^2.0.4",
+        "unist-util-visit": "^4.1.0"
+      }
+    },
+    "node_modules/@flowershow/remark-embed": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@flowershow/remark-embed/-/remark-embed-1.0.0.tgz",
+      "integrity": "sha512-tADovIrhbmNWJj72C+pgT921+BuApmO6xxKU3HlWciRHkD6S4KqsikLjsopalK+VJmqluoHhhST0kf0S6xUKIA==",
+      "dependencies": {
+        "unist-util-visit": "^4.1.1"
+      }
+    },
+    "node_modules/@flowershow/remark-wiki-link": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@flowershow/remark-wiki-link/-/remark-wiki-link-1.0.0.tgz",
+      "integrity": "sha512-biDcLXrkbqMpS1gEamVdF4P1yzH5Z+UH1YGstUflTwnxcfjLHdeG8dNUXDcGhQEvMNvaey4kSzrmglIsucuCew==",
+      "dependencies": {
+        "mdast-util-wiki-link": "^0.0.2"
+      }
     },
     "node_modules/@grpc/grpc-js": {
       "version": "1.7.3",
@@ -8729,6 +8758,32 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@fal-works/esbuild-plugin-global-externals/-/esbuild-plugin-global-externals-2.1.2.tgz",
       "integrity": "sha512-cEee/Z+I12mZcFJshKcCqC8tuX5hG3s+d+9nZ3LabqKF1vKdF41B92pJVCBggjAGORAeOzyyDDKrZwIkLffeOQ=="
+    },
+    "@flowershow/remark-callouts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@flowershow/remark-callouts/-/remark-callouts-1.0.0.tgz",
+      "integrity": "sha512-zzHDpw1bswTTf+cbhNh2Bogf4ghpIcxAypFxYZxZ/afeGdN3NNSQwnamL8StY9uu6aQ/miq4Egbuof3xk2ksWA==",
+      "requires": {
+        "mdast-util-from-markdown": "^1.2.0",
+        "svg-parser": "^2.0.4",
+        "unist-util-visit": "^4.1.0"
+      }
+    },
+    "@flowershow/remark-embed": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@flowershow/remark-embed/-/remark-embed-1.0.0.tgz",
+      "integrity": "sha512-tADovIrhbmNWJj72C+pgT921+BuApmO6xxKU3HlWciRHkD6S4KqsikLjsopalK+VJmqluoHhhST0kf0S6xUKIA==",
+      "requires": {
+        "unist-util-visit": "^4.1.1"
+      }
+    },
+    "@flowershow/remark-wiki-link": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@flowershow/remark-wiki-link/-/remark-wiki-link-1.0.0.tgz",
+      "integrity": "sha512-biDcLXrkbqMpS1gEamVdF4P1yzH5Z+UH1YGstUflTwnxcfjLHdeG8dNUXDcGhQEvMNvaey4kSzrmglIsucuCew==",
+      "requires": {
+        "mdast-util-wiki-link": "^0.0.2"
+      }
     },
     "@grpc/grpc-js": {
       "version": "1.7.3",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
   },
   "dependencies": {
     "@docsearch/react": "^3.2.0",
+    "@flowershow/remark-callouts": "^1.0.0",
+    "@flowershow/remark-embed": "^1.0.0",
+    "@flowershow/remark-wiki-link": "^1.0.0",
     "@headlessui/react": "^1.6.6",
     "@heroicons/react": "^1.0.4",
     "@silvenon/remark-smartypants": "^1.0.0",

--- a/pages/tools/view.js
+++ b/pages/tools/view.js
@@ -1,27 +1,23 @@
-import fs from 'fs'
-import path from 'path'
+import parse from "../../lib/markdown.js";
+import { getContentFromUrl } from "lib/remoteFiles";
 
-import parse from '../../lib/markdown.js'
-
-import DRD from '../../components/drd/DRD'
-
+import DRD from "../../components/drd/DRD";
 
 export default function DRDPage({ source, frontMatter }) {
-  return (
-    <DRD source={source} frontMatter={frontMatter} />
-  )
+  return <DRD source={source} frontMatter={frontMatter} />;
 }
 
-export const getStaticProps = async ({ params }) => {
-  const mdxPath = path.join('content', 'drd', 'demo.mdx')
-  const source = fs.readFileSync(mdxPath)
+export const getServerSideProps = async ({ query, res }) => {
+  const { url } = query;
 
-  const { mdxSource, frontMatter } = await parse(source)
+  const fileContent = await getContentFromUrl(url);
+
+  const { mdxSource, frontMatter } = await parse(fileContent, url);
 
   return {
     props: {
       source: mdxSource,
       frontMatter: frontMatter,
     },
-  }
-}
+  };
+};


### PR DESCRIPTION
- We can now use `/tools/view?url=...` to render MD and MDX files. E.g http://localhost:3000/tools/view?url=https://raw.githubusercontent.com/datopian/datahub-next/main/content/drd/demo.mdx#footnotes
- Flowershow remark and rehype plugins installed:
  - Remark
    - GFM
    - TOC
    - Math (not working on Next.js because it causes a hydration problem, see https://github.com/remarkjs/remark-math/issues/80)
    - Smartypants
    - Callouts
    - Embed
    - Wikilink
    - Mermaid  (not working for now)
  - Rehype
    - Prism plus 
    - Auto link headings
    - Slug 
    - Mathjax (disabled for now because remark-math is not working)
  -  ![ss-2023-03-01-20:02:58](https://user-images.githubusercontent.com/16550934/222286579-618efc9f-910a-4acf-a2c8-6421482adbd6.png)


**Deploy failing because we're using export to build the static site and there's a `getServerSideProps` in `pages/tools/view.js`** 