### PR TITLE
Markdown pipeline fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ search.json
 /test-results/
 /playwright-report/
 /playwright/.cache/
+/content/_test
 
 # markdowndb
 *.db

--- a/__tests__/e2e/index.spec.js
+++ b/__tests__/e2e/index.spec.js
@@ -1,16 +1,29 @@
 // @ts-check
 const { test, expect } = require('@playwright/test');
 
-test('has title', async ({ page }) => {
-  await page.goto('/');
 
-  await expect(page).toHaveTitle(/DataHub/);
+test.describe.parallel("Basics", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/_test/markdown');
+  });
+
+  test('has title', async ({ page }) => {
+    await expect(page).toHaveTitle(/DataHub/);
+  });
+
+  test('has blog posts index page', async ({ page }) => {
+    await page.getByRole('link', { name: /BLOG/ }).click();
+    await expect(page).toHaveURL("/blog");
+  });
 });
 
-test('has blog posts index page', async ({ page }) => {
-  await page.goto('/');
+test.describe.parallel("MDX features", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/_test/markdown');
+  });
 
-  await page.getByRole('link', { name: /BLOG/ }).click();
-
-  await expect(page).toHaveURL("/blog");
+  test("simple expression", async ({ page }) => {
+    await expect(page.locator("#simple-expression > p")).toContainText(/Two 🍰 is: 6.28/);
+  });
 });
+

--- a/__tests__/e2e/index.spec.js
+++ b/__tests__/e2e/index.spec.js
@@ -4,7 +4,7 @@ const { test, expect } = require('@playwright/test');
 
 test.describe.parallel("Basics", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/_test/markdown');
+    await page.goto('/');
   });
 
   test('has title', async ({ page }) => {
@@ -17,6 +17,8 @@ test.describe.parallel("Basics", () => {
   });
 });
 
+
+
 test.describe.parallel("MDX features", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/_test/markdown');
@@ -27,3 +29,35 @@ test.describe.parallel("MDX features", () => {
   });
 });
 
+
+test.describe.parallel("wiki links", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/_test/markdown');
+  });
+
+  test("parses a wiki link", async ({ page }) => {
+    const link = page.locator("#wiki-link > p > a");
+    await link.click();
+    await expect(page).toHaveURL("/_test/example");
+  });
+
+  test("parses a wiki link with alias", async ({ page }) => {
+    const link = page.locator("#wiki-link-alias > p > a");
+    await expect(link).toContainText("Example with alias");
+    await link.click();
+    await expect(page).toHaveURL("/_test/example");
+  });
+
+  // TODO
+  // test("parses a wiki link with header", async ({ page }) => {
+  //   const link = page.locator("#wiki-link-heading > p > a");
+  //   await link.click();
+  //   await expect(page).toHaveURL("/_test/example#abcd");
+  // });
+
+  // TODO
+  // test("link to image file", async ({ page }) => {
+  //   const link = page.locator("#wiki-link-image > p > img");
+  //   await expect(link).toHaveAttribute("src", "/Excalidraw/markdown-processing-pipeline-2023-02-23.excalidraw.svg");
+  // });
+});

--- a/__tests__/fixtures/mdx/markdown.md
+++ b/__tests__/fixtures/mdx/markdown.md
@@ -147,4 +147,20 @@ Nested:
 [[test/test]]
 
 
+## Expressions
+
+{/* export const authors = [
+   {name: 'Jane', email: 'hi@jane.com'},
+   {name: 'John', twitter: '@john2002'}
+ ]
+export const published = new Date('2022-02-01')
+ 
+Written by: {new Intl.ListFormat('en').format(authors.map(d => d.name))}.
+ 
+Published on: {new Intl.DateTimeFormat('en', {dateStyle: 'long'}).format(published)}. */}
+
+<div id="simple-expression">
+Two 🍰 is: {Math.PI * 2}
+</div>
+
 

--- a/__tests__/fixtures/mdx/markdown.md
+++ b/__tests__/fixtures/mdx/markdown.md
@@ -134,18 +134,21 @@ function fancyAlert(arg) {
 
 ## Wiki Links
 
-Simple:
+<div id="wiki-link">
 [[example]]
+</div>
 
-With alias:
+<div id="wiki-link-alias">
 [[example|Example with alias]]
+</div>
 
-🚧 To heading:
+<div id="wiki-link-heading">
 [[example#abcd|Example heading]]
+</div>
 
-Nested:
-[[test/test]]
-
+<div id="wiki-link-image">
+![[/Excalidraw/markdown-processing-pipeline-2023-02-23.excalidraw.svg]]
+</div>
 
 ## Expressions
 

--- a/content/notes/contentbase.md
+++ b/content/notes/contentbase.md
@@ -20,4 +20,4 @@ Aside: storage is probably hybrid. text files etc plus assets.
 
 What are the key components of a ContentBase? Same as a database.
 
-![[../Excalidraw/contentbase-components-2023-03-06.excalidraw.svg]]
+![](../excalidraw/contentbase-components-2023-03-06.excalidraw.svg)

--- a/content/notes/markdown-pipeline.md
+++ b/content/notes/markdown-pipeline.md
@@ -23,7 +23,7 @@ renderer --> output((Output e.g. html))
 
 ## Sketch 2023-02-23
 
-![[../Excalidraw/markdown-processing-pipeline-2023-02-23.excalidraw.svg]]
+![](/Excalidraw/markdown-processing-pipeline-2023-02-23.excalidraw.svg)
 
 
 ## Aside: re markdown and its extensions
@@ -72,4 +72,4 @@ https://mdxjs.com/docs/what-is-mdx/
 
 ## How Markdown Pipeline Complexity Arises 2023-03-06
 
-![[../Excalidraw/markdown-pipeline-complexity-evolution-2023-03-06.excalidraw.svg]]
+![](/Excalidraw/markdown-pipeline-complexity-evolution-2023-03-06.excalidraw.svg)

--- a/content/notes/plan.md
+++ b/content/notes/plan.md
@@ -11,11 +11,11 @@ Taglines
 - Publish, organize and find data
 - Wrangle, Preview, Deploy
 
-![[../Excalidraw/datahub-next-github-v0.1-20220218.svg]]
+![](/Excalidraw/datahub-next-github-v0.1-20220218.svg)
 
 More complex version with multiple documents, multiple assets
 
-![[../Excalidraw/datahub-next-github-many-files-v0.1-2023-02-27.excalidraw.svg]]
+![](/Excalidraw/datahub-next-github-many-files-v0.1-2023-02-27.excalidraw.svg)
 
 # Workstreams
 

--- a/lib/markdown.mjs
+++ b/lib/markdown.mjs
@@ -72,7 +72,7 @@ const parse = async function (source, format) {
                       xmlns: "http:www.w3.org/2000/svg",
                       fill: "#ab2b65",
                       viewBox: "0 0 20 20",
-                      className: "w-5 h-5 inline-block mr-2",
+                      className: "w-5 h-5",
                     },
                     [
                       h("path", {

--- a/lib/markdown.mjs
+++ b/lib/markdown.mjs
@@ -89,7 +89,7 @@ const parse = async function (source, format) {
           [rehypeKatex, { output: "mathml" }],
           [rehypePrismPlus, { ignoreMissing: true }],
         ],
-        format: "detect",
+        format,
       },
       scope: data,
     }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "next start",
     "export": "npm run build && next export",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
-    "test:e2e": "playwright test"
+    "test:e2e": "./scripts/testsetup.sh && playwright test && ./scripts/testteardown.sh"
   },
   "dependencies": {
     "@flowershow/core": "^0.4.2",

--- a/scripts/testsetup.sh
+++ b/scripts/testsetup.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+ln -vfns ../__tests__/fixtures/mdx content/_test

--- a/scripts/testteardown.sh
+++ b/scripts/testteardown.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+rm content/_test

--- a/styles/global.css
+++ b/styles/global.css
@@ -27,46 +27,42 @@ html {
 }
 
 /* hide anchor link with # icon  */
-.unstyled :is(h1, h2, h3, h4, h5, h6) > a {
-  visibility: hidden;
-}
-
-.docs :is(h1, h2, h3, h4, h5, h6) {
+:is(h1, h2, h3, h4, h5, h6) {
   margin-left: -2rem !important;
   padding-left: 2rem !important;
   scroll-margin-top: 4.5rem;
   position: relative;
 }
 
-.docs :is(h1, h2, h3, h4, h5, h6) > a {
-  padding: 1px;
+:is(h1, h2, h3, h4, h5, h6) > a {
   position: absolute;
   left: 0;
   top: 50%;
   transform: translateY(-50%);
   margin: auto 0;
+  padding: 1px;
   border-radius: 5px;
   background: #1e293b;
   opacity: 0;
   transition: opacity 0.2s;
 }
 
-.light .docs :is(h1, h2, h3, h4, h5, h6) > a {
+.light :is(h1, h2, h3, h4, h5, h6) > a {
   /* border: 1px solid #ab2b65; */
   /* background: none; */
   background: #e2e8f0;
 }
 
-.docs :is(h1, h2, h3, h4, h5, h6):hover > a {
+:is(h1, h2, h3, h4, h5, h6):hover > a {
   opacity: 100;
 }
 
-.docs :is(h1, h2, h3, h4, h5, h6) > a > svg {
+:is(h1, h2, h3, h4, h5, h6) > a > svg {
   transform: scale(0.75);
 }
 
 @media screen and (max-width: 640px) {
-  .docs :is(h1, h2, h3, h4, h5, h6) > a {
+  :is(h1, h2, h3, h4, h5, h6) > a {
     visibility: hidden;
   }
 }


### PR DESCRIPTION
Closes #70 

## Changes
- add E2E tests for simple JS expressions
- add E2E tests for wiki links
- replace `![[link]]` with `![](link)` in a few files (temporary solution for Obsidian's syntax not being supported by `remark-wiki-link` package)
- add `testsetup.sh` and `testteardown.sh` scripts and adjust `test:e2e` npm script
- fix `#`icons showing on hover over headings