### PR TITLE
Fix callouts syntax in MD content

### DIFF
--- a/content/blog/automated-kpis-collection-and-visualization-of-the-funnels.md
+++ b/content/blog/automated-kpis-collection-and-visualization-of-the-funnels.md
@@ -53,9 +53,8 @@ We have defined couple of initial funnels that we think is important. We conside
 
 Below we have written how "views" property would look like in the `datapackage.json` file:
 
-:::info
-In order to define how the graphs should look like we add a "views" property to `datapackage.json` file that will tell DataHub platform to create graphs on our page. By just editing a few lines in "views" property we can easily change the appearance of our graphs on the whim. Things like which stats to create graph for, which time period to display, average and max values etc.
-:::
+>[!info] In order to define how the graphs should look like we add a "views" property to `datapackage.json` file that will tell DataHub platform to create graphs on our page. By just editing a few lines in "views" property we can easily change the appearance of our graphs on the whim. Things like which stats to create graph for, which time period to display, average and max values etc.
+
 
 ```json
 {

--- a/content/blog/core-data-essential-datasets-for-data-wranglers-and-data-scientists.md
+++ b/content/blog/core-data-essential-datasets-for-data-wranglers-and-data-scientists.md
@@ -12,7 +12,7 @@ https://datahub.io/docs/core-data
 
 This post introduces you to the Core Data, presents a couple of examples and shows you how you can access and use core data easily from your own tools and systems including R, Python, Pandas and more.
 
-[[toc]]
+## Table of Contents
 
 ## Why Core Data
 
@@ -92,11 +92,8 @@ If you just need to get data, you have a direct link usable from any tool or app
 * CSV - https://datahub.io/core/country-list/r/data.csv
 * JSON - https://datahub.io/core/country-list/r/data.json
 
-:::info
-For more read our "Getting Data" tutorial:
-
+> [!info]For more read our "Getting Data" tutorial:
 https://datahub.io/docs/getting-started/getting-data
-:::
 
 
 ### cURL

--- a/content/blog/data-validation-in-the-datahub.md
+++ b/content/blog/data-validation-in-the-datahub.md
@@ -21,9 +21,8 @@ cd my-data-datapackage
 data push
 ```
 
-:::info
+>[!info]
 You can find more about pushing data to the DataHub [here](http://datahub.io/docs/getting-started/publishing-data).
-:::
 
 You may need to customize the schema for your file -- perhaps DataHub has guessed the types wrong.
 

--- a/content/blog/excel-files-on-the-datahub-automated-previews-and-data-extraction.md
+++ b/content/blog/excel-files-on-the-datahub-automated-previews-and-data-extraction.md
@@ -56,9 +56,9 @@ Once your data is online, you will see the following page:
 
 ![](/static/img/docs/showcase-excel-1.png)
 
-:::info
-DataHub may still be processing your data. In this case you will see an appropriate message on the page. Just allow it couple of moments and it will be there!
-:::
+
+> [!info]DataHub may still be processing your data. In this case you will see an appropriate message on the page. Just allow it couple of moments and it will be there!
+
 
 We have converted the first sheet to CSV. If you take a look at downloads table, there are options to get data in CSV or JSON versions. Also, you still can download your original data:
 

--- a/content/blog/how-to-initialize-a-data-package-using-data-tool.md
+++ b/content/blog/how-to-initialize-a-data-package-using-data-tool.md
@@ -6,9 +6,10 @@ authors: ['anuveyatsu']
 
 In this article we explain how easy is adding a `datapackage.json` file for your data. You need to have `data` tool installed - [download it](https://datahub.io/download) and follow these [instructions](https://datahub.io/docs/getting-started/installing-data).
 
-:::info
-If you're not familiar with `datapackage.json`, please, read this article - https://datahub.io/docs/data-packages.
-:::
+
+>[!info]If you're not familiar with 'datapackage.json', 
+Please, read this article - https://datahub.io/docs/data-packages.
+
 
 Below is how our project looks like initially:
 
@@ -63,7 +64,7 @@ If you take a look at `datapackage.json`, you'd mention that:
 
 If you need more control, e.g., you want to add only certain files, scan certain directories and add a different license, you can use `init` command in interactive mode:
 
-```
+```etc
 $ data init -i
 ```
 
@@ -71,7 +72,7 @@ $ data init -i
 
 You can now deploy your dataset to DataHub:
 
-```
+```etc
 $ data push
 ```
 

--- a/content/blog/import-online-data-files-directly-with-scheduling.md
+++ b/content/blog/import-online-data-files-directly-with-scheduling.md
@@ -14,13 +14,13 @@ We're very excited about this feature as it is the first step in supporting auto
 
 We'll use an example of the "Energy consumption by sector" from the US Energy Information Administration. This data is updated on monthly basis so we want it to be re-imported every 30 days (~1 month):
 
-```
+```etc
 data push https://www.eia.gov/totalenergy/data/browser/csv.php?tbl=T02.01 --schedule="every 30d" --format=csv
 ```
 
-:::info
-By default, when you push datasets to DataHub, they are "unlisted" so only people with the link can see it. If you wish to make your dataset "published", you need to pass `--published` option: `data push URL --published`.
-:::
+
+>[!info]By default, when you push datasets to DataHub, they are "unlisted" so only people with the link can see it. 
+If you wish to make your dataset "published", you need to pass the `--published` option: `data push URL --published`.
 
 Once the process is completed open your browser and check it out! It would generate a URL using your username, which will be copied to clipboard so you can just open a browser and paste it. You should see something similar to this page:
 

--- a/content/blog/improved-reporting-and-debugging-of-data-publishing.md
+++ b/content/blog/improved-reporting-and-debugging-of-data-publishing.md
@@ -33,6 +33,6 @@ Each time you publish your dataset, a revision process is triggered for it. You 
 
 It becomes useful when you've re-published your dataset several times and you want to get your data in a specific stage.
 
-:::info
-A version is a natural number (integer larger than 0) and you can access the specific version of a dataset by `/v/{number}`.
-:::
+
+>[!info]A version is a natural number (integer larger than 0) and you can access the specific version of a dataset by:
+`/v/{number}`.

--- a/content/blog/introducing-private-datasets-on-the-datahub.md
+++ b/content/blog/introducing-private-datasets-on-the-datahub.md
@@ -24,21 +24,19 @@ Once you are ready to publish your data, just select "private" option and then p
 
 ![](/static/img/docs/push-private.png)
 
-:::info
-Learn more about using the "Data" app [here](http://datahub.io/blog/data-desktop-app-alpha-release).
-:::
+
+>[!info]Learn more about using the "Data" app [here](http://datahub.io/blog/data-desktop-app-alpha-release).
 
 ### Publish using the command line tool
 
 Simply pass `--private` flag when you "push" your data so once it is processed and online only you can view it:
 
-```
+```etc
 $ data push myData --private
 ```
 
-:::info
-Learn more about how to publish datasets using the CLI [here](http://datahub.io/docs/getting-started/publishing-data).
-:::
+>[!info]Learn more about how to publish datasets using the CLI:
+http://datahub.io/docs/getting-started/publishing-data
 
 
 ## Making a Private Dataset Public

--- a/content/blog/online-validation-tool.md
+++ b/content/blog/online-validation-tool.md
@@ -16,11 +16,9 @@ The descriptor should be stored online, e.g. on the github.
 
 You should provide the URL to the descriptor (datapackage.json) file and press 'Validate' button.
 
-:::info
-Online validator tool validates only the descriptor file.
-
+>[!info]Online validator tool validates only the descriptor file.
 Here you can read about the [full data validation on the DataHub](https://datahub.io/blog/data-validation-in-the-datahub).
-:::
+
 
 ## How we validate
 

--- a/content/collections/war-and-peace.md
+++ b/content/collections/war-and-peace.md
@@ -22,9 +22,8 @@ Some of most relevant:
   * CodeBook: http://ucdp.uu.se/downloads/ucdpprio/ucdp-prio-acd-172.pdf
 
 
-:::info
-Note: PRIO dataset https://www.prio.org/Data/Armed-Conflict/Battle-Deaths/ merged into Uppsala Conflict Data Program (UCDP) dataset
-:::
+>[!info]Note: PRIO dataset merged into Uppsala Conflict Data Program (UCDP) dataset.
+https://www.prio.org/Data/Armed-Conflict/Battle-Deaths/
 
 ## Correlates of War
 

--- a/content/docs/data-packages/data-packages.md
+++ b/content/docs/data-packages/data-packages.md
@@ -41,7 +41,7 @@ Packages including for creating, viewing and validating.
 ## Getting Started
 
 A minimal example Data Package would look like this on disk:
-```
+```etc
 datapackage.json
 # a data file (CSV in this case but could be any type of data)
 data.csv
@@ -79,17 +79,12 @@ minimal example of a `datapackage.json` file:
 
 Here is a much more extensive example of a datapackage JSON file:
 
-:::info
-**Note:** a complete list of potential attributes and their meaning can be found in the
-[full Data Package spec][spec].
-:::
+>[!info] A complete list of potential attributes and their meaning can be found in:
+[Full Data Package spec](https://frictionlessdata.io/specs/data-package/)
 
-[spec]: https://frictionlessdata.io/specs/data-package/
-
-:::info
-**Note:** the Data Package format is **extensible** in that it allows you add
+>[!note]**Note:** The Data Package format is **extensible** in that it allows you add
 your own attributes to the `datapackage.json`
-:::
+
 ```javascript
     {
       "name": "a-unique-human-readable-and-url-usable-identifier",

--- a/content/docs/dms/ckan-client-guide/index.md
+++ b/content/docs/dms/ckan-client-guide/index.md
@@ -11,9 +11,7 @@ This guide is about adding and managing data in CKAN programmatically and it ass
 
 Clients use [Frictionless formats](https://specs.frictionlessdata.io/) by default for describing dataset and resource objects passed to client methods. Internally, we then use the a *CKAN {'<=>'} Frictionless Mapper* (both [in JavaScript]( https://github.com/datopian/frictionless-ckan-mapper-js ) and [in Python](https://github.com/frictionlessdata/frictionless-ckan-mapper)) to convert objects to CKAN formats before calling the API. **Thus, you can use _Frictionless Formats_ by default with the client**.
 
-::::tip
-As CKAN moves to Frictionless to default this will gradually become unnecessary.
-::::
+>[!tip]As CKAN moves to Frictionless to default this will gradually become unnecessary.
 
 ## Quick start
 
@@ -84,9 +82,8 @@ client.push(resource)
 
 ### Adding a resource to an existing Dataset
 
-::::tip NOTE
-Not implemented yet.
-::::
+>[!note]Not implemented yet.
+
 
 ```python
 client.create('my-data')
@@ -95,9 +92,8 @@ client.push_resource(resource)
 
 ### Edit a Dataset's metadata
 
-:::tip NOTE
-Not implemented yet.
-:::
+>[!note]Not implemented yet.
+
 
 ```python
 dataset = client.retrieve('sample-dataset')
@@ -145,11 +141,9 @@ Arguments:
 | `transform_payload`  | `function` | `None`     | Function to mutate the `payload` before making the request (useful to convert to and from CKAN and Frictionless formats). |
 | `transform_response` | `function` | `None`     | function to mutate the response data before returning it (useful to convert to and from CKAN and Frictionless formats). |
 
-::::tip NOTE
-The CKAN API uses the CKAN dataset and resource formats (rather than Frictionless formats).
-
+>[!note]The CKAN API uses the CKAN dataset and resource formats (rather than Frictionless formats).
 In other words, to stick to Frictionless formats, you can pass `frictionless_ckan_mapper.frictionless_to_ckan` as `transform_payload`, and `frictionless_ckan_mapper.ckan_to_frictionless` as `transform_response`.
-::::
+
 
 #### In JavaScript
 
@@ -161,17 +155,13 @@ Arguments:
 | `payload`    | <code>object</code> | (required)         | The payload being sent to CKAN. When a payload is provided to a GET request, it will be converted to URL parameters and each key will be converted to snake case. |
 | `useHttpGet` | <code>object</code> | <code>false</code> | Optional, if `True` will make `GET` request, otherwise `POST`. |
 
-::::tip NOTE
-The JavaScript implementation uses the CKAN dataset and resource formats (rather than Frictionless formats).
-
+>[!note]The JavaScript implementation uses the CKAN dataset and resource formats (rather than Frictionless formats).
 In other words, to stick to Frictionless formats, you need to convert from Frictionless to CKAN before calling `action` , and from CKAN to Frictionless after calling `action`.
-::::
 
 ## Metadata reference
 
-:::tip NOTE
-Your site may have custom metadata that differs from the example set below.
-:::
+>[!info]Your site may have custom metadata that differs from the example set below.
+
 
 ### Profile
 
@@ -371,7 +361,7 @@ $ npm install -g git+https://github.com/datopian/jsv.git
 $ jsv data-resource.json --output py
 ```
 
-:::details Output
+**Output**
 ```python
 dataset_metadata = {
     "profile": "data-resource",  # The profile of this descriptor.
@@ -397,7 +387,7 @@ dataset_metadata = {
     # [example] "hash": "SHA256:5262f12512590031bbcc9a430452bfd75c2791ad6771320bb4b5728bfb78c4d0"
 }
 ```
-::::
+
 
 ### JavaScript
 
@@ -405,7 +395,7 @@ dataset_metadata = {
 $ jsv data-resource.json --output js
 ```
 
-::::details Output
+**Output**
 ```javascript
 const datasetMetadata = {
   // The profile of this descriptor.
@@ -457,7 +447,6 @@ const datasetMetadata = {
   // [example] hash: "SHA256:5262f12512590031bbcc9a430452bfd75c2791ad6771320bb4b5728bfb78c4d0"
 };
 ```
-::::
 
 ### R
 
@@ -465,7 +454,7 @@ const datasetMetadata = {
 $ jsv data-resource.json --output r
 ```
 
-::::details Output
+**Output** 
 ```r
 # The profile of this descriptor.
 profile <- "data-resource"
@@ -505,7 +494,7 @@ hash <- "d25c9c77f588f5dc32059d2da1136c02"
 # [example] hash <- "SHA256:5262f12512590031bbcc9a430452bfd75c2791ad6771320bb4b5728bfb78c4d0"
 
 ```
-::::
+
 
 ## Design Principles
 

--- a/content/docs/dms/ckan-v3/index.md
+++ b/content/docs/dms/ckan-v3/index.md
@@ -51,9 +51,7 @@ The main way to address these problems while gaining extra benefits is to move t
 
 Thus, we recommend building the next version of CKAN – CKAN v3 – on a microservices approach.
 
-:::tip
-CKAN v3 is sometimes also referred to as CKAN Next Gen(eration).
-:::
+[!tip]CKAN v3 is sometimes also referred to as CKAN Next Gen(eration).
 
 With microservices, each piece of functionality runs in its own service and process. 
 
@@ -159,9 +157,8 @@ This diagram is based on the file `docker-compose.yml` of [github.com/okfn/docke
  
 A difference from this diagram to the file is that we are not including DataPusher, as it is not a required dependency.
 
-:::tip
-Databases may run as Docker containers, or rely on third-party services such as Amazon Relational Database Service (RDS).
-:::
+>[!tip]Databases may run as Docker containers, or rely on third-party services such as Amazon Relational Database Service (RDS).
+
 
 
 ```mermaid

--- a/content/docs/dms/ckan/create-extension.md
+++ b/content/docs/dms/ckan/create-extension.md
@@ -34,9 +34,7 @@ CKAN__PLUGINS=stats text_view recline_view example_extension
 # Shut down your instance with crtl+c and then run it again with:
 docker-compose -f docker-compose.dev.yml up
 ```
-::: tip
-CKAN will be started running on the paster development server with the `--reload` option to watch changes in the extension files.
-:::
+> [!tip]CKAN will be started running on the paster development server with the '--reload' option to watch changes in the extension files.
 
 You should see the following output in the console:
 
@@ -52,9 +50,7 @@ Let's edit a template to change the way CKAN is displayed to the user!
 
 1. First you will need write permissions to the extension folder since it was created by the user running docker. Replace `your_username` and execute the following command:
 
-::: tip
-You can find out your current username by typing `echo $USER` in the terminal.
-:::
+> [!tip]You can find out your current username by typing 'echo $USER' in the terminal.
 
 ```
 sudo chown -R <your_username>:<your_username> src/ckanext-example_extension

--- a/content/docs/dms/ckan/getting-started.md
+++ b/content/docs/dms/ckan/getting-started.md
@@ -33,8 +33,7 @@ cp .env.example .env
 
 Build and Run the instances:
 
-::: tip
-`docker-compose` must be run with `sudo`. If you want to change this, you can follow the steps below. NOTE: The `docker` group grants privileges equivalent to the `root` user.  
+> [!tip]'docker-compose' must be run with 'sudo'. If you want to change this, you can follow the steps below. NOTE: The 'docker' group grants privileges equivalent to the 'root' user.  
 
 Create the `docker` group: `sudo groupadd docker`  
 
@@ -48,7 +47,6 @@ RUN chown -R ckan:ckan /var/lib/ckan/storage
 ```
 
 At this point, you can log out and log back in for these changes to apply. You can also use the command `newgrp docker` to temporarily enable the new group for the current terminal session.
-:::
 
 ```
 docker-compose -f docker-compose.dev.yml up --build
@@ -64,9 +62,9 @@ You can navigate to `http://localhost:5000`
 
 and log in with the credentials that docker-compose setup created for you [user: `ckan_admin` password:`test1234`].
 
-::: tip
-To learn key concepts about CKAN, including what it is and how it works, you can read the [CKAN User Guide](https://docs.ckan.org/en/2.8/user-guide.html).
-:::
+>[!tip]To learn key concepts about CKAN, including what it is and how it works, you can read the User Guide.
+[CKAN User Guide](https://docs.ckan.org/en/2.8/user-guide.html).
+
 
 ## Next Steps
 

--- a/content/docs/dms/ckan/play-around.md
+++ b/content/docs/dms/ckan/play-around.md
@@ -15,17 +15,17 @@ CKAN is a tool for making data portals to manage and publish datasets. You can r
 
 https://docs.ckan.org/en/2.9/user-guide.html
 
-::: tip
+>[!tip]
 Install a [JSON formatter plugin for Chrome](https://chrome.google.com/webstore/detail/json-formatter/bcjindcccaagfpapjjmafapmmgkkhgoa?hl=en) or browser of your choice.
 
 If you are familiar with the command line tool `curl`, you can use that.
 
 In this tutorial, we will be using `curl`, but for most of the commands, you can paste a link in your browser. For POST commands, you can use [Postman](https://www.getpostman.com/) or [Google Chrome Plugin](https://chrome.google.com/webstore/detail/postman/fhbjgbiflinjbdggehcddcbncdddomop).
-:::
+
 
 ## First steps
 
-::: tip
+>[!tip]
 By default the portal is accessible on http://localhost:5000. Let's update your `/etc/hosts` to access it on http://ckan:5000:
 
 ```
@@ -34,7 +34,6 @@ vi /etc/hosts      # You can use the editor of your choice
 127.0.0.1 ckan
 ```
 
-:::
 
 At this point, you should be able to access the portal on http://ckan:5000.
 

--- a/content/docs/dms/data-api.md
+++ b/content/docs/dms/data-api.md
@@ -76,9 +76,7 @@ The functionality associated to the Data APIs can be divided in 6 areas:
   * Maybe includes some ETL => this takes us more into data factory
 * **Storage (Structured)**: the underlying structured store for the data (and its layout). For example, Postgres and its table structure.This could be considered a separate component that the Data API uses or as part of the Data API -- in some cases the store and API are completely wrapped together, e.g. ElasticSearch is both a store and a rich Web API.
 
-:::tip
-**Visualization** is not part of the API but the demands of visualization are important in designing the system.
-:::
+>[!tip]Visualization is not part of the API but the demands of visualization are important in designing the system.
 
 ## Job Stories
 
@@ -162,9 +160,7 @@ As a Publisher I want to only allow specific people to access data via the data 
 
 ### UI for Exploring Data
 
-:::warning
-This probably is *not* a Data API epic -- rather it would come under the Data Explorer.
-:::
+>[!warning]This probably is not a Data API epic -- rather it would come under the Data Explorer.
 
 * I want an interface to “sql style” query data
 * I want a filter interface into data
@@ -214,11 +210,11 @@ The CKAN DataStore extension provides an ad-hoc database for storage of structur
 
 See the DataStore extension: https://github.com/ckan/ckan/tree/master/ckanext/datastore
 
-Datastore API: https://docs.ckan.org/en/2.8/maintaining/datastore.html#the-datastore-api
+[Datastore API](https://docs.ckan.org/en/2.8/maintaining/datastore.html#the-datastore-api)
 
-Making Datastore API requests: https://docs.ckan.org/en/2.8/maintaining/datastore.html#making-a-datastore-api-request
+[Making Datastore API requests](https://docs.ckan.org/en/2.8/maintaining/datastore.html#making-a-datastore-api-request)
 
-Example: Create a DataStore table: https://docs.ckan.org/en/2.8/maintaining/datastore.html#ckanext.datastore.logic.action.datastore_create
+[Example: Create a DataStore table](https://docs.ckan.org/en/2.8/maintaining/datastore.html#ckanext.datastore.logic.action.datastore_create)
 
 ```sh
 curl -X POST http://127.0.0.1:5000/api/3/action/datastore_create \

--- a/content/docs/dms/data-explorer/design.md
+++ b/content/docs/dms/data-explorer/design.md
@@ -1,8 +1,7 @@
 # Data Explorer Design
 
-:::tip NOTE
+>[!note]
 Design sketches from Aug 2019. This remains a work in progress though a good part was implemented in the new [Data Explorer](/docs/dms/data-explorer).
-:::
 
 ## Job Stories
 

--- a/content/docs/dms/flows/history.md
+++ b/content/docs/dms/flows/history.md
@@ -2,16 +2,16 @@
 
 Date: 2018-04-08
 
-:::tip NOTE
-This is a miscellaneous content from various HackMD docs. I'm preserving because either a) there is material to reuse here that I'm not sure is elsewhere b) there were various ideas in here we used later (and it's useful to see their origins).
+> [!note]
+>This is a miscellaneous content from various HackMD docs. I'm preserving because either a) there is material to reuse here that I'm not sure is elsewhere b) there were various ideas in here we used later (and it's useful to see their origins).
+>
+>Key content:
+>
+>* March-April 2018: first planning of what became dataflows (had various names including dataos). A lot of my initial ideas ended up in this micro-demo https://github.com/datopian/dataflow-demo. This evolved with Adam into https://github.com/datahq/dataflows
+>* Autumn 2017: planning of Data Factory which was the data processing system inside DataHub.io. This was more extensive than dataflows (e.g. it included a runner, an assembler etc) and was based original data-package-pipelines and its runner. Issues with that system was part of the motivation for starting work on dataflows.
+>
+>~Rufus May 2020
 
-Key content:
-
-* March-April 2018: first planning of what became dataflows (had various names including dataos). A lot of my initial ideas ended up in this micro-demo https://github.com/datopian/dataflow-demo. This evolved with Adam into https://github.com/datahq/dataflows
-* Autumn 2017: planning of Data Factory which was the data processing system inside DataHub.io. This was more extensive than dataflows (e.g. it included a runner, an assembler etc) and was based original data-package-pipelines and its runner. Issues with that system was part of the motivation for starting work on dataflows.
-
-~Rufus May 2020
-:::
 
 
 ## Plan April 2018

--- a/content/docs/dms/frontend/index.md
+++ b/content/docs/dms/frontend/index.md
@@ -2,11 +2,11 @@
 
 The (read) frontend component covers all of the traditional "read" frontend functionality of a data portal: front page, searching datasets, viewing datasets etc.
 
-:::tip 📣 Announcing Portal.js
-Portal.js 🌀 is a javascript framework for building rich data portal frontends fast using a modern frontend approach (JavaScript, React, SSR).
+>[!tip]Announcing Portal.js📣 
+>Portal.js 🌀 is a javascript framework for building rich data portal frontends fast using a modern frontend approach (JavaScript, React, SSR).
+>
+>https://github.com/datopian/portal.js
 
-https://github.com/datopian/portal.js
-:::
 
 ## Features
 
@@ -96,19 +96,17 @@ In more detail:
 
 ## CKAN v3
 
-:::tip 📣 Announcing Portal.js
-Portal.js 🌀 is a javascript framework for building rich data portal frontends fast using a modern frontend approach (JavaScript, React, SSR).
-
-https://github.com/datopian/portal.js
-:::
+>[!tip]Announcing Portal.js📣 
+>Portal.js 🌀 is a javascript framework for building rich data portal frontends fast using a modern frontend approach (JavaScript, React, SSR).
+>
+>https://github.com/datopian/portal.js
 
 Previous (stable) version is `frontend-v2`: https://github.com/datopian/frontend-v2. It is written in NodeJS using ExpressJS. For templating it uses [Nunjucks][].
 
 [Nunjucks]: https://mozilla.github.io/nunjucks/templating.html
 
-:::tip
-Note: it is easy to write your own Next Gen frontend in any language or framework you like -- much like the frontend of a headless CMS site. And obviously you can still reuse the patterns (and even code if you are using JS) from the default approach presented here.
-:::
+>[!note]It is easy to write your own Next Gen frontend in any language or framework you like -- much like the frontend of a headless CMS site. And obviously you can still reuse the patterns (and even code if you are using JS) from the default approach presented here.
+
 
 ## RFC
 

--- a/content/docs/dms/hubstore.md
+++ b/content/docs/dms/hubstore.md
@@ -1,8 +1,7 @@
 # HubStore
 
-:::warning Work in Progress
+> [!warning]Work in Progress
 This is is early stage and still a work in progress.
-:::
 
 A HubStore maintains a catalog of organizations and their ownership of projects / datasets.
 

--- a/content/docs/dms/index.md
+++ b/content/docs/dms/index.md
@@ -49,9 +49,8 @@ A DMS has a variety of features. This section provides an overview and links to 
 
 <img src="https://docs.google.com/drawings/d/e/2PACX-1vRdMzNeIAEkjDRGtBfuocy6zDyRg_qDujSkLrTe69U1qlu_1kfTYN0OL_v4IZKKo0eDXRbCzgzQMlFz/pub?w=622&amp;h=635" />
 
-:::tip
-There are many ways to break down features and this is just one framing. We are thinking about others and if you have thoughts please get in touch.
-:::
+> [!tip] There are many ways to break down features and this is just one framing. We are thinking about others and if you have thoughts please get in touch.
+
 
 - [Discovering and showcasing data (catalog and presenting)](/docs/dms/frontend)
 - [Views on data](/docs/dms/views) including visualizing and previewing data as well [Data Explorers][explorer] and [Dashboards][]
@@ -77,7 +76,7 @@ A DMS has the following key components:
 
 https://coggle.it/diagram/Xiw2ZmYss-ddJVuK/t/data-portal-feature-breakdown
 
-<iframe width='853' height='480' src='https://embed.coggle.it/diagram/Xiw2ZmYss-ddJVuK/b24d6f959c3718688fed2a5883f47d33f9bcff1478a0f3faf9e36961ac0b862f' frameBorder='0' allowFullScreen></iframe>
+<iframe width='540' height='480' src='https://embed.coggle.it/diagram/Xiw2ZmYss-ddJVuK/b24d6f959c3718688fed2a5883f47d33f9bcff1478a0f3faf9e36961ac0b862f' frameBorder='0' allowFullScreen></iframe>
 
 ## Frictionless
 

--- a/content/docs/dms/notebook/index.md
+++ b/content/docs/dms/notebook/index.md
@@ -477,9 +477,7 @@ TODO: take a screenshot to illustrate Gitlab and Github.
 
 4 Stores of a DataHub
 
-:::tip
-Naming is one of the most important things -- and hardest!
-:::
+>[!tip]Naming is one of the most important things -- and hardest!
 
 * MetaStore [service]: API (and store) of the metadata for datasets
 * HubStore [service]: API for registry of datasets (+ potentially organizations and ownership relationships to datasets)

--- a/content/docs/dms/publish.md
+++ b/content/docs/dms/publish.md
@@ -49,9 +49,7 @@ More specifically: As a Data Curator I want to drop a file in and edit the metad
 
 #### Resources
 
-:::tip
-A resource is any data item in a dataset e.g. a file.
-:::
+>[!tip]A resource is any data item in a dataset e.g. a file.
 
 When adding a resource to a dataset I want metadata pre-entered for me (e.g. resource name from file name, encoding, ...) to save time and reduce errors
 
@@ -196,15 +194,14 @@ addres --> save
 addmeta -.-> save
 ```
 
-:::tip Comment: The file driven approach is preferable
-We think the "file driven" approach where the flow starts with a user adding and uploading a file (and then adding metadata) is preferable to an metadata driven approach where you start with a dataset and metatdata and then add files (as is the default today in CKAN).
+>[!tip]Comment: The file driven approach is preferable.
+We think the "file driven" approach where the flow starts with a user adding and uploading a file (and then adding metadata) is preferable to a metadata driven approach where you start with a dataset and metadata and then add files (as is the default today in CKAN).  
 
-Why do we think a file driven approach is better? a) a file is what the user has immediately to hand b) it is concrete whilst "metadata" is abstract c) common tools for storing files e.g. Dropbox or Google Drive start with providing a file - only later, and optionally, do you rename it, move it etc.
+Why do we think a file driven approach is better? a) a file is what the user has immediately to hand b) it is concrete whilst "metadata" is abstract c) common tools for storing files e.g. Dropbox or Google Drive start with providing a file - only later, and optionally, do you rename it, move it etc. 
 
 That said, tools like GitHub or Gitlab require one to create a "project", albeit a minimal one, before being able to push any content. However, GitHub and Gitlab are developer oriented tools that can assume a willingness to tolerate a slightly more cumbersome UX. Furthermore, the default use case is that you have a git repo that you wish to push so the the use case of a non-technical user uploading files is clearly secondary. Finally, in these systems you can create a project just to have an issue tracker or wiki (without having fiile storage). In this case, creating the project first makes sense.
 
 In a DMS, we are often dealing with non-technical or semi-technical users. Thus, providing a simple, intuitive flow is preferable. That said, one may still have a very lightweight project creation flow so that we have a container for the files (just as in, say, Google Drive you already have a folder to put your files in).
-:::
 
 
 ### Dataset Metadata editor
@@ -287,7 +284,7 @@ Advanced:
 
 **Deck**: This deck (Feb 2019) provides an overview of the core flow publishing a single tabular file e.g. CSV and includes a a basic UI mockup illustrating the flow described below.
 
-<iframe src="https://docs.google.com/presentation/d/e/2PACX-1vQD09jo3Mwq-jM32rns_ehyd6GOv7cQ7F9UAK1U_jzO5G4ZgZ8ktG9rwK03-N-0XmQyJx-9kSW7-U4I/embed?start=false&loop=false&delayms=3000" frameborder="0" width="960" height="569" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true" />
+<iframe src="https://docs.google.com/presentation/d/e/2PACX-1vQD09jo3Mwq-jM32rns_ehyd6GOv7cQ7F9UAK1U_jzO5G4ZgZ8ktG9rwK03-N-0XmQyJx-9kSW7-U4I/embed?start=false&loop=false&delayms=3000" frameborder="0" width="550" height="569" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true" />
 
 #### Overview
 

--- a/content/docs/dms/storage.md
+++ b/content/docs/dms/storage.md
@@ -5,8 +5,6 @@ Data Portals often need to *store* data 😉 As such, they require a system for 
 * [Blob Storage][] (aka Bulk or Raw): for storing data as "blobs", a raw stream of bytes like files on a filesystem. Think local filesystem or cloud storage like S3, GCS, etc. See [Blob Storage][] for more on this.
 * Structured Storage: for storing data in a structured way e.g. tabular data in a relational database or "documents" in a document database.
 
-:::tip
-In CKAN 2 Blob Storage (and associated functionality) was known as FileStore and Structured Storage was known as DataStore.
-:::
+>[!tip]In CKAN 2 Blob Storage (and associated functionality) was known as FileStore and Structured Storage was known as DataStore.
 
 [Blob Storage]: /docs/dms/blob-storage

--- a/content/docs/dms/views.md
+++ b/content/docs/dms/views.md
@@ -23,9 +23,7 @@ In addition, we may want:
 * **Explorers**: that build on the views and wizards to allow users to do interactive data exploratio via live filtering and viewing.
 * **Dashboards** that combine tables, charts, maps etc (often with widgets that allow users to adjust these e.g. to select a country that updates associated charts).
 
-:::tip
-Often when we say "view" we identify with the particular presentation such as the table or graph. E.g. we say "this table is a view of that data". However, when you stop and think, strictly a view is more than that, for example it includes the title for the table. Formally, for us a view will include the combination of the presentation specification, the data sources that feed, plus any general metadata such as a title and description.
-:::
+>[!tip]Often when we say "view" we identify with the particular presentation such as the table or graph. E.g. we say "this table is a view of that data". However, when you stop and think, strictly a view is more than that, for example it includes the title for the table. Formally, for us a view will include the combination of the presentation specification, the data sources that feed, plus any general metadata such as a title and description.
 
 ## Definitions
 

--- a/content/docs/dms/views/design.md
+++ b/content/docs/dms/views/design.md
@@ -4,9 +4,9 @@ Design of [Views](/docs/dms/views).
 
 ## Concepts and Background
 
-:::tip
+>[!tip]
 This is from https://specs.frictionlessdata.io/views/#concepts-and-background
-:::
+
 
 To generate visualizations you usually want the following 3 types of information:
 
@@ -53,10 +53,8 @@ graph TD
   vega --render--> html
 ```
 
-:::info
-**IMPORTANT**: an important "convention" we adopt for the "compiling-in" of data is that resource data should be inlined into an `_values` attribute. If the data is tabular this attribute should be an array of *arrays* (not objects).
-:::
-
+>[!info]Important
+An important "convention" we adopt for the "compiling-in" of data is that resource data should be inlined into an `_values` attribute. If the data is tabular this attribute should be an array of *arrays* (not objects).
 
 ### Graphs
 
@@ -86,11 +84,10 @@ Notes:
 
 ### Geo support
 
-:::info
-**Note**: support for customizing map is limited to JS atm - there is no real map "spec" in JSON yet beyond the trivial version.
+>[!note]Support for customizing map is limited to JS atm - there is no real map "spec" in JSON yet beyond the trivial version.
 
-**Note**: vega has some geo support but geo here means full geojson style mapping.
-:::
+>[!note]Vega has some geo support but geo here means full geojson style mapping.
+
 
 ```mermaid
 graph LR

--- a/content/docs/features/auto-generated-csv-json-and-zip.md
+++ b/content/docs/features/auto-generated-csv-json-and-zip.md
@@ -13,9 +13,9 @@ We auto generate compressed `ZIP` versions of datasets so users can download ent
 
 Once downloaded you would get all available versions of the data along with the descriptor (metadata) file called "datapackage.json".
 
-:::info
-All datasets on DataHub are "packaged" as data packages (read more about it - http://datahub.io/docs/data-packages)
-:::
+>[!info]All datasets on DataHub are "packaged" as data packages 
+Read more about it - http://datahub.io/docs/data-packages
+
 
 ## CSV and JSON
 

--- a/content/docs/getting-started/how-to-use-info-cat-and-get-commands-of-data-tool.md
+++ b/content/docs/getting-started/how-to-use-info-cat-and-get-commands-of-data-tool.md
@@ -32,18 +32,17 @@ which will print out README of the dataset + summary table about available resou
 
 You can see that it has `global` CSV file, derived CSV and JSON versions of it, a validation report and ZIP version of the dataset.
 
-:::info
-Read more about derived CSV and JSON of a tabular data and ZIP version of the datasets:
+>[!info]Read more about derived CSV and JSON of a tabular data and ZIP version of the datasets:
 https://datahub.io/docs/features/auto-generated-csv-json-and-zip
-:::
+
 
 # Preview tabular data
 
 Let's preview `global` CSV file so we know how data looks like before downloading it. We can do it by using `cat` command:
 
-:::info
-If you wonder how we constructed the above URL, read this docs about "r" links - https://datahub.io/docs/getting-started/getting-data#perma-urls-for-data.
-:::
+>[!info]If you wonder how we constructed the URL, read this docs about "r" links:
+https://datahub.io/docs/getting-started/getting-data#perma-urls-for-data.
+
 
 ```
 data cat https://datahub.io/core/co2-fossil-global/r/global.csv

--- a/content/docs/getting-started/installing-data.md
+++ b/content/docs/getting-started/installing-data.md
@@ -29,11 +29,9 @@ chmod +x data-macos
 mv data-macos /usr/local/bin/data
 ```
 
-:::info
-If you have an error message saying `no such file or directory`, you might need to create a directory in your `/usr/local/` by running:
-
+>[!info]If you have an error message saying 'no such file or directory', you might need to create a directory in your '/usr/local/' by running:
 `mkdir /usr/local/bin`
-:::
+
 
 ## Linux
 
@@ -43,11 +41,9 @@ chmod +x data-linux
 mv data-linux /usr/local/bin/data
 ```
 
-:::info
-If you encounter errors related to location of `xdg-open` package, following may help:
-
+>[!info]If you encounter errors related to location of 'xdg-open' package, following may help:
 `cp /usr/bin/xdg-open /usr/local/bin/xdg-open`
-:::
+
 
 ## Windows
 

--- a/content/docs/getting-started/publishing-data.md
+++ b/content/docs/getting-started/publishing-data.md
@@ -8,9 +8,9 @@ This guide walks you through how to put data online using **data** tool and the 
 
 Here we focus on tabular data and especially CSV - a universal basic format for structured data.
 
-:::info
-You can read and learn about CSV in [this post](/docs/data-packages/csv).
-:::
+>[!info]You can read and learn about CSV in:
+[This post.](/docs/data-packages/csv)
+
 
 ## Install the data CLI tool
 

--- a/content/docs/getting-started/push-excel.md
+++ b/content/docs/getting-started/push-excel.md
@@ -6,11 +6,9 @@ excerpt: In this tutorial, we will explain how to push Excel data to the DataHub
 
 In this tutorial, we will explain how to push Excel data to the DataHub. When an Excel file is pushed, we can extract data from selected sheets for previewing and downloading in alternative formats. By default, our CLI tool would process only first sheet of the Excel, but publishers can specify any sheets they want.
 
-:::info
-Find out how to install our CLI tool here:
-
+[!info]Find out how to install our CLI tool here:
 http://datahub.io/docs/getting-started/installing-data
-:::
+
 
 ## Get some Excel data
 
@@ -62,9 +60,8 @@ Once your data is online, you will see the following page:
 
 ![](/static/img/docs/showcase-excel-1.png)
 
-:::info
-DataHub may still be processing your data. In this case you will see an appropriate message on the page. Just allow it couple of moments and it will be there!
-:::
+>[!info]DataHub may still be processing your data. In this case you will see an appropriate message on the page. Just allow it couple of moments and it will be there!
+
 
 We have converted the first sheet to CSV. If you take a look at downloads table, there are options to get data in CSV or JSON versions. Also, you still can download your original data:
 

--- a/content/docs/misc/markdown.md
+++ b/content/docs/misc/markdown.md
@@ -119,21 +119,19 @@ And our site will use this metadata while forming the page. The result you can s
 
 If you will add `[[toc]]` in your document - this will be automatically transformed into Table Of Content section, with links to all your Headers.
 
-### Info boxes
+### Directive boxes (Callouts)
 
-You can add info boxes in your text and the message will appear in a box with orange borders:
+You can add info boxes in your text and the message will appear in a colored box:
 
-```
-:::info
-My important message here.
-:::
+```etc
+>[!info]My important message here.
 ```
 
 and this is how it would be rendered:
 
-:::info
-My important message here.
-:::
+> [!info]My important message here.
+
+For more supported callouts please refer to https://flowershow.app/docs/callouts
 
 ### CLI output
 

--- a/content/docs/tutorials/js-sdk-tutorial.md
+++ b/content/docs/tutorials/js-sdk-tutorial.md
@@ -36,9 +36,9 @@ npm install datahub-client data.js --save
 
 2. Make sure you have configurations file at `~/.config/datahub/config.json`.
 
-:::info
+>[!info]
 If you don't have it, you need to generate using our [CLI tool](https://datahub.io/download). After running `data login` command, credentials can be found at `~/.config/datahub/config.json`.
-:::
+
 
 ### Push code example
 


### PR DESCRIPTION
All the MD content that was not rendering callouts in the new Flowershow callout syntax, e.g.
![image](https://user-images.githubusercontent.com/101370137/229896112-486e4192-b75c-47f0-bda4-cef287c276df.png)

Now is being rendered properly

![image](https://user-images.githubusercontent.com/101370137/229896354-d2c3e598-7488-41c3-91c1-596eb686abb8.png)

Also some iframes and links were shortened in width to fullfill the container properly.